### PR TITLE
Better wkhtmltopdf binary support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,17 @@ source "https://rubygems.org"
 gem "sinatra"
 gem "octokit"
 gem "pdfkit"
-gem "wkhtmltopdf-binary", git: "https://github.com/zakird/wkhtmltopdf_binary_gem"
 gem "dotenv"
 gem "rack-ssl-enforcer"
 gem "foreman"
+
+group :production do
+  gem 'wkhtmltopdf-heroku'
+end
+
+group :development, :test do
+  gem 'wkhtmltopdf-binary-edge'
+end
 
 group :test do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/zakird/wkhtmltopdf_binary_gem
-  revision: 77a62c35e4a9bb8d6583ffeadf0073ac92748a91
-  specs:
-    wkhtmltopdf-binary (0.9.9.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -60,6 +54,8 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    wkhtmltopdf-binary-edge (0.12.2.1)
+    wkhtmltopdf-heroku (2.12.2.4)
 
 PLATFORMS
   ruby
@@ -77,7 +73,8 @@ DEPENDENCIES
   sinatra
   vcr
   webmock
-  wkhtmltopdf-binary!
+  wkhtmltopdf-binary-edge
+  wkhtmltopdf-heroku
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
Using https://github.com/rposborne/wkhtmltopdf-heroku and https://github.com/pallymore/wkhtmltopdf-binary-edge.